### PR TITLE
Windows WWIV Update v2.0.41.5

### DIFF
--- a/windows-wwiv-update/Form2.cs
+++ b/windows-wwiv-update/Form2.cs
@@ -244,7 +244,7 @@ namespace windows_wwiv_update
                         {
                             entry.ExtractToFile(Path.Combine(extractPath, entry.FullName), true);
                         }
-                        if (entry.FullName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                        if (entry.FullName.EndsWith("sbbsexec.dll", StringComparison.OrdinalIgnoreCase))
                         {
                             entry.ExtractToFile(Path.Combine(extractPath2, entry.FullName), true);
                         }

--- a/windows-wwiv-update/Properties/AssemblyInfo.cs
+++ b/windows-wwiv-update/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.42.1")]
-[assembly: AssemblyFileVersion("2.0.42.1")]
+[assembly: AssemblyVersion("2.0.42.5")]
+[assembly: AssemblyFileVersion("2.0.42.5")]

--- a/windows-wwiv-update/Settings.cs
+++ b/windows-wwiv-update/Settings.cs
@@ -1,0 +1,28 @@
+﻿namespace windows_wwiv_update.Properties {
+    
+    
+    // This class allows you to handle specific events on the settings class:
+    //  The SettingChanging event is raised before a setting's value is changed.
+    //  The PropertyChanged event is raised after a setting's value is changed.
+    //  The SettingsLoaded event is raised after the setting values are loaded.
+    //  The SettingsSaving event is raised before the setting values are saved.
+    internal sealed partial class Settings {
+        
+        public Settings() {
+            // // To add event handlers for saving and changing settings, uncomment the lines below:
+            //
+            // this.SettingChanging += this.SettingChangingEventHandler;
+            //
+            // this.SettingsSaving += this.SettingsSavingEventHandler;
+            //
+        }
+        
+        private void SettingChangingEventHandler(object sender, System.Configuration.SettingChangingEventArgs e) {
+            // Add code to handle the SettingChangingEvent event here.
+        }
+        
+        private void SettingsSavingEventHandler(object sender, System.ComponentModel.CancelEventArgs e) {
+            // Add code to handle the SettingsSaving event here.
+        }
+    }
+}

--- a/windows-wwiv-update/windows-wwiv-update.csproj
+++ b/windows-wwiv-update/windows-wwiv-update.csproj
@@ -24,7 +24,7 @@
     <UpdatePeriodically>false</UpdatePeriodically>
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>1</ApplicationRevision>
+    <ApplicationRevision>5</ApplicationRevision>
     <ApplicationVersion>2.0.42.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>


### PR DESCRIPTION
Fix for cl32.dll NOT to be copied into the System32 directory like the sbbsexec.dll is. No need to have unused .dll's in System32.